### PR TITLE
feat(cairo): using snapshot (@) to reduce the unnecessary cloning of Bytes and Message

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Build the rust code
         run: |
-          cd rust && cargo build --release
+          cd rust && cargo build
 
       - name: Install starknet-devnet
         run: |
-          cargo install starknet-devnet --locked
+          curl -sSfL https://github.com/0xSpaceShard/starknet-devnet/releases/download/v0.0.6/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xvz -C /usr/local/bin
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install starknet-devnet
         run: |
-          curl -sSfL https://github.com/0xSpaceShard/starknet-devnet/releases/download/v0.0.6/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xvz -C /usr/local/bin
+          curl -sSfL https://github.com/0xSpaceShard/starknet-devnet/releases/download/v0.4.0/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xvz -C /usr/local/bin
 
       - name: Build contracts
         run: |
@@ -31,8 +31,6 @@ jobs:
       - name: Build the rust code
         run: |
           cd rust && cargo build
-
-
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           scarb-version: "2.10.1"
 
+      - name: Install starknet-devnet
+        run: |
+          curl -sSfL https://github.com/0xSpaceShard/starknet-devnet/releases/download/v0.0.6/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xvz -C /usr/local/bin
+
       - name: Build contracts
         run: |
           cd cairo && scarb build
@@ -28,9 +32,7 @@ jobs:
         run: |
           cd rust && cargo build
 
-      - name: Install starknet-devnet
-        run: |
-          curl -sSfL https://github.com/0xSpaceShard/starknet-devnet/releases/download/v0.0.6/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xvz -C /usr/local/bin
+
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/cairo/crates/contracts/src/client/gas_router_component.cairo
+++ b/cairo/crates/contracts/src/client/gas_router_component.cairo
@@ -139,7 +139,7 @@ pub mod GasRouterComponent {
         ) -> u256 {
             let mailbox_comp = get_dep_component!(self, MailBoxClient);
             let hook = mailbox_comp.get_hook();
-            self._Gas_router_quote_dispatch(destination_domain, BytesTrait::new_empty(), hook)
+            self._Gas_router_quote_dispatch(destination_domain, @BytesTrait::new_empty(), hook)
         }
     }
 
@@ -165,7 +165,7 @@ pub mod GasRouterComponent {
             ref self: ComponentState<TContractState>,
             destination: u32,
             value: u256,
-            message_body: Bytes,
+            message_body: @Bytes,
             hook: ContractAddress,
         ) -> u256 {
             let mut router_comp = get_dep_component_mut!(ref self, Router);
@@ -182,7 +182,7 @@ pub mod GasRouterComponent {
         fn _Gas_router_quote_dispatch(
             self: @ComponentState<TContractState>,
             destination: u32,
-            message_body: Bytes,
+            message_body: @Bytes,
             hook: ContractAddress,
         ) -> u256 {
             let mut router_comp = get_dep_component!(self, Router);

--- a/cairo/crates/contracts/src/client/router_component.cairo
+++ b/cairo/crates/contracts/src/client/router_component.cairo
@@ -247,7 +247,7 @@ pub mod RouterComponent {
             self: @ComponentState<TContractState>,
             destination_domain: u32,
             value: u256,
-            message_body: Bytes,
+            message_body: @Bytes,
             hook_metadata: Bytes,
             hook: ContractAddress,
         ) -> u256 {
@@ -279,7 +279,7 @@ pub mod RouterComponent {
         fn _Router_quote_dispatch(
             self: @ComponentState<TContractState>,
             destination_domain: u32,
-            message_body: Bytes,
+            message_body: @Bytes,
             hook_metadata: Bytes,
             hook: ContractAddress,
         ) -> u256 {

--- a/cairo/crates/contracts/src/hooks/domain_routing_hook.cairo
+++ b/cairo/crates/contracts/src/hooks/domain_routing_hook.cairo
@@ -144,9 +144,7 @@ pub mod domain_routing_hook {
                         caller, configured_hook_address, required_amount,
                     );
             };
-            self
-                ._get_configured_hook(_message)
-                .post_dispatch(_metadata, _message, required_amount);
+            self._get_configured_hook(_message).post_dispatch(_metadata, _message, required_amount);
         }
 
         /// Quotes the dispatch fee for a given message. The hook to be selected will be based on

--- a/cairo/crates/contracts/src/hooks/libs/standard_hook_metadata.cairo
+++ b/cairo/crates/contracts/src/hooks/libs/standard_hook_metadata.cairo
@@ -35,7 +35,7 @@ pub mod standard_hook_metadata {
         /// # Returns
         ///
         /// u16 -  variant of the metadata
-        fn variant(_metadata: Bytes) -> u16 {
+        fn variant(_metadata: @Bytes) -> u16 {
             if (_metadata.size() < VARIANT_OFFSET.into() + 2) {
                 return 0;
             }
@@ -53,7 +53,7 @@ pub mod standard_hook_metadata {
         /// # Returns
         ///
         /// u256 -  Value for the message
-        fn msg_value(_metadata: Bytes, _default: u256) -> u256 {
+        fn msg_value(_metadata: @Bytes, _default: u256) -> u256 {
             if (_metadata.size() < MSG_VALUE_OFFSET.into() + 32) {
                 return _default;
             }
@@ -71,7 +71,7 @@ pub mod standard_hook_metadata {
         /// # Returns
         ///
         /// u256 -  Gas limit for the message
-        fn gas_limit(_metadata: Bytes, _default: u256) -> u256 {
+        fn gas_limit(_metadata: @Bytes, _default: u256) -> u256 {
             if (_metadata.size() < GAS_LIMIT_OFFSET.into() + 32) {
                 return _default;
             }
@@ -89,7 +89,7 @@ pub mod standard_hook_metadata {
         /// # Returns
         ///
         /// ContractAddress -  Refund address for the message
-        fn refund_address(_metadata: Bytes, _default: ContractAddress) -> ContractAddress {
+        fn refund_address(_metadata: @Bytes, _default: ContractAddress) -> ContractAddress {
             if (_metadata.size() < REFUND_ADDRESS_OFFSET.into() + 32) {
                 return _default;
             }
@@ -106,7 +106,7 @@ pub mod standard_hook_metadata {
         /// # Returns
         ///
         /// Bytes -  Custom metadata.
-        fn get_custom_metadata(_metadata: Bytes) -> Bytes {
+        fn get_custom_metadata(_metadata: @Bytes) -> Bytes {
             if (_metadata.size().into() < MIN_METADATA_LENGTH) {
                 return BytesTrait::new_empty();
             }
@@ -150,19 +150,19 @@ mod tests {
     #[test]
     fn test_standard_hook_metadata_default_value() {
         let mut metadata = BytesTrait::new_empty();
-        assert_eq!(0, StandardHookMetadata::variant(metadata.clone()));
+        assert_eq!(0, StandardHookMetadata::variant(@metadata));
         let variant = 1;
         metadata.append_u16(variant);
-        assert_eq!(123, StandardHookMetadata::msg_value(metadata.clone(), 123));
+        assert_eq!(123, StandardHookMetadata::msg_value(@metadata, 123));
         let msg_value = 0x123123123;
         metadata.append_u256(msg_value);
-        assert_eq!(4567, StandardHookMetadata::gas_limit(metadata.clone(), 4567));
+        assert_eq!(4567, StandardHookMetadata::gas_limit(@metadata, 4567));
         let gas_limit = 0x456456456;
         metadata.append_u256(gas_limit);
         let other_refunded_address = 'other_refunded'.try_into().unwrap();
         assert_eq!(
             other_refunded_address,
-            StandardHookMetadata::refund_address(metadata.clone(), other_refunded_address),
+            StandardHookMetadata::refund_address(@metadata, other_refunded_address),
         );
         let refund_address: ContractAddress = 'refund_address'.try_into().unwrap();
         metadata.append_address(refund_address);
@@ -185,15 +185,15 @@ mod tests {
         let mut expected_custom_metadata = BytesTrait::new_empty();
         expected_custom_metadata.append_u256(*custom_metadata.at(0));
         expected_custom_metadata.append_u256(*custom_metadata.at(1));
-        assert_eq!(variant, StandardHookMetadata::variant(metadata.clone()));
-        assert_eq!(msg_value, StandardHookMetadata::msg_value(metadata.clone(), 0));
-        assert_eq!(gas_limit, StandardHookMetadata::gas_limit(metadata.clone(), 0));
+        assert_eq!(variant, StandardHookMetadata::variant(@metadata));
+        assert_eq!(msg_value, StandardHookMetadata::msg_value(@metadata, 0));
+        assert_eq!(gas_limit, StandardHookMetadata::gas_limit(@metadata, 0));
         assert_eq!(
             refund_address,
-            StandardHookMetadata::refund_address(metadata.clone(), contract_address_const::<0>()),
+            StandardHookMetadata::refund_address(@metadata, contract_address_const::<0>()),
         );
         assert(
-            expected_custom_metadata == StandardHookMetadata::get_custom_metadata(metadata.clone()),
+            expected_custom_metadata == StandardHookMetadata::get_custom_metadata(@metadata),
             'SHM: custom metadata mismatch',
         );
     }

--- a/cairo/crates/contracts/src/hooks/merkle_tree_hook.cairo
+++ b/cairo/crates/contracts/src/hooks/merkle_tree_hook.cairo
@@ -11,7 +11,10 @@ pub mod merkle_tree_hook {
     };
     use contracts::interfaces::{IMailboxClient, IMerkleTreeHook, IPostDispatchHook, Types};
     use contracts::libs::message::{Message, MessageTrait};
-    use contracts::utils::{keccak256::{ByteData, HASH_SIZE, compute_keccak, reverse_endianness}, utils::{SerdeSnapshotBytes, SerdeSnapshotMessage}};
+    use contracts::utils::{
+        keccak256::{ByteData, HASH_SIZE, compute_keccak, reverse_endianness},
+        utils::{SerdeSnapshotBytes, SerdeSnapshotMessage},
+    };
     use openzeppelin::access::ownable::OwnableComponent;
     use starknet::ContractAddress;
     use starknet::storage::{

--- a/cairo/crates/contracts/src/hooks/protocol_fee.cairo
+++ b/cairo/crates/contracts/src/hooks/protocol_fee.cairo
@@ -6,6 +6,7 @@ pub mod protocol_fee {
     };
     use contracts::interfaces::{IPostDispatchHook, IProtocolFee, Types};
     use contracts::libs::message::Message;
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
@@ -80,7 +81,7 @@ pub mod protocol_fee {
         /// # Returns
         ///
         /// boolean - whether the hook supports metadata
-        fn supports_metadata(self: @ContractState, _metadata: Bytes) -> bool {
+        fn supports_metadata(self: @ContractState, _metadata: @Bytes) -> bool {
             _metadata.size() == 0 || StandardHookMetadata::variant(_metadata) == VARIANT.into()
         }
 
@@ -93,9 +94,9 @@ pub mod protocol_fee {
         /// * - `_message` - the message passed from the Mailbox.dispatch() call
         /// * - `_fee_amount` - the payment provided for sending the message
         fn post_dispatch(
-            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256,
+            ref self: ContractState, _metadata: @Bytes, _message: @Message, _fee_amount: u256,
         ) {
-            assert(self.supports_metadata(_metadata.clone()), Errors::INVALID_METADATA_VARIANT);
+            assert(self.supports_metadata(_metadata), Errors::INVALID_METADATA_VARIANT);
             self._post_dispatch(_metadata, _message, _fee_amount);
         }
 
@@ -110,8 +111,8 @@ pub mod protocol_fee {
         /// # Returns
         ///
         /// u256 - Quoted payment for the postDispatch call
-        fn quote_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) -> u256 {
-            assert(self.supports_metadata(_metadata.clone()), Errors::INVALID_METADATA_VARIANT);
+        fn quote_dispatch(ref self: ContractState, _metadata: @Bytes, _message: @Message) -> u256 {
+            assert(self.supports_metadata(_metadata), Errors::INVALID_METADATA_VARIANT);
             self._quote_dispatch(_metadata, _message)
         }
     }
@@ -169,7 +170,7 @@ pub mod protocol_fee {
         /// * - `_message` - the message passed from the Mailbox.dispatch() call
         /// * - `_fee_amount` - the payment provided for sending the message
         fn _post_dispatch(
-            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256,
+            ref self: ContractState, _metadata: @Bytes, _message: @Message, _fee_amount: u256,
         ) { // Since payment is exact, no need for further operation
         }
 
@@ -183,7 +184,7 @@ pub mod protocol_fee {
         /// # Returns
         ///
         /// u256 - Quoted payment for the postDispatch call
-        fn _quote_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) -> u256 {
+        fn _quote_dispatch(ref self: ContractState, _metadata: @Bytes, _message: @Message) -> u256 {
             self.protocol_fee.read()
         }
 

--- a/cairo/crates/contracts/src/interfaces.cairo
+++ b/cairo/crates/contracts/src/interfaces.cairo
@@ -1,8 +1,8 @@
 use alexandria_bytes::Bytes;
 use contracts::hooks::merkle_tree_hook::merkle_tree_hook::Tree;
 use contracts::libs::message::Message;
-use core::array::ArrayTrait;
 use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
+use core::array::ArrayTrait;
 use starknet::ContractAddress;
 use starknet::EthAddress;
 

--- a/cairo/crates/contracts/src/interfaces.cairo
+++ b/cairo/crates/contracts/src/interfaces.cairo
@@ -2,6 +2,7 @@ use alexandria_bytes::Bytes;
 use contracts::hooks::merkle_tree_hook::merkle_tree_hook::Tree;
 use contracts::libs::message::Message;
 use core::array::ArrayTrait;
+use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
 use starknet::ContractAddress;
 use starknet::EthAddress;
 
@@ -58,7 +59,7 @@ pub trait IMailbox<TContractState> {
         ref self: TContractState,
         _destination_domain: u32,
         _recipient_address: u256,
-        _message_body: Bytes,
+        _message_body: @Bytes,
         _fee_amount: u256,
         _custom_hook_metadata: Option<Bytes>,
         _custom_hook: Option<ContractAddress>,
@@ -68,12 +69,12 @@ pub trait IMailbox<TContractState> {
         self: @TContractState,
         _destination_domain: u32,
         _recipient_address: u256,
-        _message_body: Bytes,
+        _message_body: @Bytes,
         _custom_hook_metadata: Option<Bytes>,
         _custom_hook: Option<ContractAddress>,
     ) -> u256;
 
-    fn process(ref self: TContractState, _metadata: Bytes, _message: Message);
+    fn process(ref self: TContractState, _metadata: @Bytes, _message: Message);
 
     fn recipient_ism(self: @TContractState, _recipient: u256) -> ContractAddress;
 
@@ -93,13 +94,13 @@ pub trait IMailbox<TContractState> {
 pub trait IInterchainSecurityModule<TContractState> {
     fn module_type(self: @TContractState) -> ModuleType;
 
-    fn verify(self: @TContractState, _metadata: Bytes, _message: Message) -> bool;
+    fn verify(self: @TContractState, _metadata: @Bytes, _message: @Message) -> bool;
 }
 
 #[starknet::interface]
 pub trait IValidatorConfiguration<TContractState> {
     fn validators_and_threshold(
-        self: @TContractState, _message: Message,
+        self: @TContractState, _message: @Message,
     ) -> (Span<EthAddress>, u32);
 
     fn get_validators(self: @TContractState) -> Span<EthAddress>;
@@ -117,13 +118,13 @@ pub trait ISpecifiesInterchainSecurityModule<TContractState> {
 pub trait IPostDispatchHook<TContractState> {
     fn hook_type(self: @TContractState) -> Types;
 
-    fn supports_metadata(self: @TContractState, _metadata: Bytes) -> bool;
+    fn supports_metadata(self: @TContractState, _metadata: @Bytes) -> bool;
 
     fn post_dispatch(
-        ref self: TContractState, _metadata: Bytes, _message: Message, _fee_amount: u256,
+        ref self: TContractState, _metadata: @Bytes, _message: @Message, _fee_amount: u256,
     );
 
-    fn quote_dispatch(ref self: TContractState, _metadata: Bytes, _message: Message) -> u256;
+    fn quote_dispatch(ref self: TContractState, _metadata: @Bytes, _message: @Message) -> u256;
 }
 
 
@@ -181,9 +182,9 @@ pub trait IDefaultFallbackRoutingIsm<TContractState> {
     /// Relayers infer how to fetch and format metadata.
     fn module_type(self: @TContractState) -> ModuleType;
 
-    fn route(self: @TContractState, _message: Message) -> ContractAddress;
+    fn route(self: @TContractState, _message: @Message) -> ContractAddress;
 
-    fn verify(self: @TContractState, _metadata: Bytes, _message: Message) -> bool;
+    fn verify(self: @TContractState, _metadata: @Bytes, _message: @Message) -> bool;
 }
 
 #[starknet::interface]
@@ -241,10 +242,10 @@ pub trait IAggregation<TContractState> {
     fn module_type(self: @TContractState) -> ModuleType;
 
     fn modules_and_threshold(
-        self: @TContractState, _message: Message,
+        self: @TContractState, _message: @Message,
     ) -> (Span<ContractAddress>, u8);
 
-    fn verify(self: @TContractState, _metadata: Bytes, _message: Message) -> bool;
+    fn verify(self: @TContractState, _metadata: @Bytes, _message: @Message) -> bool;
 
     fn get_modules(self: @TContractState) -> Span<ContractAddress>;
 
@@ -268,7 +269,7 @@ pub trait IMerkleTreeHook<TContractState> {
 pub trait IPausableIsm<TContractState> {
     fn module_type(self: @TContractState) -> ModuleType;
 
-    fn verify(self: @TContractState, _metadata: Bytes, _message: Message) -> bool;
+    fn verify(self: @TContractState, _metadata: Bytes, _message: @Message) -> bool;
 
     fn pause(ref self: TContractState);
 
@@ -291,7 +292,7 @@ pub trait IProtocolFee<TContractState> {
 
 #[starknet::interface]
 pub trait IRoutingIsm<TContractState> {
-    fn route(self: @TContractState, _message: Message) -> ContractAddress;
+    fn route(self: @TContractState, _message: @Message) -> ContractAddress;
 }
 
 #[derive(Drop, Serde, Copy)]

--- a/cairo/crates/contracts/src/isms/aggregation/aggregation.cairo
+++ b/cairo/crates/contracts/src/isms/aggregation/aggregation.cairo
@@ -7,7 +7,7 @@ pub mod aggregation {
     };
     use contracts::libs::aggregation_ism_metadata::aggregation_ism_metadata::AggregationIsmMetadata;
     use contracts::libs::message::Message;
-    use contracts::utils::utils::{SerdeSnapshotMessage, SerdeSnapshotBytes};
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::upgrades::upgradeable::UpgradeableComponent;
     use starknet::storage::{

--- a/cairo/crates/contracts/src/isms/multisig/merkleroot_multisig_ism.cairo
+++ b/cairo/crates/contracts/src/isms/multisig/merkleroot_multisig_ism.cairo
@@ -6,7 +6,10 @@ pub mod merkleroot_multisig_ism {
     use contracts::libs::checkpoint_lib::checkpoint_lib::CheckpointLib;
     use contracts::libs::message::{Message, MessageTrait};
     use contracts::libs::multisig::merkleroot_ism_metadata::merkleroot_ism_metadata::MerkleRootIsmMetadata;
-    use contracts::utils::{keccak256::{ByteData, HASH_SIZE, bool_is_eth_signature_valid}, utils::{SerdeSnapshotBytes, SerdeSnapshotMessage}};
+    use contracts::utils::{
+        keccak256::{ByteData, HASH_SIZE, bool_is_eth_signature_valid},
+        utils::{SerdeSnapshotBytes, SerdeSnapshotMessage},
+    };
     use openzeppelin::access::ownable::OwnableComponent;
     use starknet::ContractAddress;
     use starknet::EthAddress;
@@ -162,9 +165,7 @@ pub mod merkleroot_multisig_ism {
                 ) <= MerkleRootIsmMetadata::signed_index(_metadata),
                 Errors::INVALID_MERKLE_INDEX,
             );
-            let origin_merkle_tree_hook = MerkleRootIsmMetadata::origin_merkle_tree_hook(
-                _metadata,
-            );
+            let origin_merkle_tree_hook = MerkleRootIsmMetadata::origin_merkle_tree_hook(_metadata);
             let signed_index = MerkleRootIsmMetadata::signed_index(_metadata);
             let signed_message_id = MerkleRootIsmMetadata::signed_message_id(_metadata);
             let (id, _) = MessageTrait::format_message(_message.clone());

--- a/cairo/crates/contracts/src/isms/multisig/messageid_multisig_ism.cairo
+++ b/cairo/crates/contracts/src/isms/multisig/messageid_multisig_ism.cairo
@@ -5,7 +5,9 @@ pub mod messageid_multisig_ism {
     use contracts::libs::checkpoint_lib::checkpoint_lib::CheckpointLib;
     use contracts::libs::message::{Message, MessageTrait};
     use contracts::libs::multisig::message_id_ism_metadata::message_id_ism_metadata::MessageIdIsmMetadata;
-    use contracts::utils::{keccak256::bool_is_eth_signature_valid, utils::{SerdeSnapshotBytes, SerdeSnapshotMessage}};
+    use contracts::utils::{
+        keccak256::bool_is_eth_signature_valid, utils::{SerdeSnapshotBytes, SerdeSnapshotMessage},
+    };
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::upgrades::upgradeable::UpgradeableComponent;
     use starknet::ContractAddress;
@@ -159,14 +161,16 @@ pub mod messageid_multisig_ism {
         ///
         /// u256 - The digest to be signed by validators
         fn digest(self: @ContractState, _metadata: @Bytes, _message: @Message) -> u256 {
-            let origin_merkle_tree_hook = MessageIdIsmMetadata::origin_merkle_tree_hook(
-                _metadata,
-            );
+            let origin_merkle_tree_hook = MessageIdIsmMetadata::origin_merkle_tree_hook(_metadata);
             let root = MessageIdIsmMetadata::root(_metadata);
             let index = MessageIdIsmMetadata::index(_metadata);
             let (format_message, _) = MessageTrait::format_message(_message.clone());
             CheckpointLib::digest(
-                *_message.origin, origin_merkle_tree_hook.into(), root.into(), index, format_message,
+                *_message.origin,
+                origin_merkle_tree_hook.into(),
+                root.into(),
+                index,
+                format_message,
             )
         }
 

--- a/cairo/crates/contracts/src/isms/noop_ism.cairo
+++ b/cairo/crates/contracts/src/isms/noop_ism.cairo
@@ -3,7 +3,9 @@ pub mod noop_ism {
     use alexandria_bytes::Bytes;
     use contracts::interfaces::{IInterchainSecurityModule, ModuleType};
     use contracts::libs::message::Message;
-    use contracts::utils::utils::{U256TryIntoContractAddress, SerdeSnapshotBytes, SerdeSnapshotMessage};
+    use contracts::utils::utils::{
+        SerdeSnapshotBytes, SerdeSnapshotMessage, U256TryIntoContractAddress,
+    };
     #[storage]
     struct Storage {}
 

--- a/cairo/crates/contracts/src/isms/noop_ism.cairo
+++ b/cairo/crates/contracts/src/isms/noop_ism.cairo
@@ -3,6 +3,7 @@ pub mod noop_ism {
     use alexandria_bytes::Bytes;
     use contracts::interfaces::{IInterchainSecurityModule, ModuleType};
     use contracts::libs::message::Message;
+    use contracts::utils::utils::{U256TryIntoContractAddress, SerdeSnapshotBytes, SerdeSnapshotMessage};
     #[storage]
     struct Storage {}
 
@@ -24,7 +25,7 @@ pub mod noop_ism {
         /// # Returns
         ///
         /// boolean - wheter the verification succeed or not.
-        fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
+        fn verify(self: @ContractState, _metadata: @Bytes, _message: @Message) -> bool {
             true
         }
     }

--- a/cairo/crates/contracts/src/isms/pausable_ism.cairo
+++ b/cairo/crates/contracts/src/isms/pausable_ism.cairo
@@ -11,6 +11,7 @@ pub mod pausable_ism {
     use alexandria_bytes::Bytes;
     use contracts::interfaces::{IInterchainSecurityModule, ModuleType};
     use contracts::libs::message::Message;
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::security::pausable::PausableComponent;
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
@@ -75,7 +76,7 @@ pub mod pausable_ism {
         /// # Returns
         ///
         /// boolean - wheter the verification succeed or not.
-        fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
+        fn verify(self: @ContractState, _metadata: @Bytes, _message: @Message) -> bool {
             self.pausable.assert_not_paused();
             true
         }

--- a/cairo/crates/contracts/src/isms/routing/default_fallback_routing_ism.cairo
+++ b/cairo/crates/contracts/src/isms/routing/default_fallback_routing_ism.cairo
@@ -11,6 +11,7 @@ pub mod default_fallback_routing_ism {
         IRoutingIsm, ModuleType,
     };
     use contracts::libs::message::Message;
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
     use core::panic_with_felt252;
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::upgrades::{interface::IUpgradeable, upgradeable::UpgradeableComponent};
@@ -180,8 +181,8 @@ pub mod default_fallback_routing_ism {
         /// # Returns
         ///
         /// ContractAddress - The ISM address to use to verify _message
-        fn route(self: @ContractState, _message: Message) -> ContractAddress {
-            self.module(_message.origin)
+        fn route(self: @ContractState, _message: @Message) -> ContractAddress {
+            self.module(*_message.origin)
         }
     }
 
@@ -204,8 +205,8 @@ pub mod default_fallback_routing_ism {
         /// # Returns
         ///
         /// boolean - wheter the verification succeed or not.
-        fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
-            let ism_address = self.route(_message.clone());
+        fn verify(self: @ContractState, _metadata: @Bytes, _message: @Message) -> bool {
+            let ism_address = self.route(_message);
             let ism_dispatcher = IInterchainSecurityModuleDispatcher {
                 contract_address: ism_address,
             };

--- a/cairo/crates/contracts/src/isms/routing/domain_routing_ism.cairo
+++ b/cairo/crates/contracts/src/isms/routing/domain_routing_ism.cairo
@@ -6,6 +6,7 @@ pub mod domain_routing_ism {
         IInterchainSecurityModuleDispatcherTrait, IRoutingIsm, ModuleType,
     };
     use contracts::libs::message::Message;
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
     use core::panic_with_felt252;
 
     use openzeppelin::access::ownable::OwnableComponent;
@@ -86,7 +87,7 @@ pub mod domain_routing_ism {
             let mut cur_idx = 0;
             loop {
                 if (cur_idx == _domains.len()) {
-                    break ();
+                    break;
                 }
                 assert(
                     *_modules.at(cur_idx) != contract_address_const::<0>(),
@@ -135,7 +136,7 @@ pub mod domain_routing_ism {
                 let next_domain = self.domains.read(current_domain);
                 if next_domain == 0 {
                     domains.append(current_domain);
-                    break ();
+                    break;
                 }
                 domains.append(current_domain);
                 current_domain = next_domain;
@@ -171,8 +172,8 @@ pub mod domain_routing_ism {
         /// # Returns
         ///
         /// ContractAddress - the ISM contract address
-        fn route(self: @ContractState, _message: Message) -> ContractAddress {
-            self.module(_message.origin)
+        fn route(self: @ContractState, _message: @Message) -> ContractAddress {
+            self.module(*_message.origin)
         }
     }
 
@@ -194,8 +195,8 @@ pub mod domain_routing_ism {
         /// # Returns
         ///
         /// boolean - wheter the verification succeed or not.
-        fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
-            let ism_address = self.route(_message.clone());
+        fn verify(self: @ContractState, _metadata: @Bytes, _message: @Message) -> bool {
+            let ism_address = self.route(_message);
             let ism_dispatcher = IInterchainSecurityModuleDispatcher {
                 contract_address: ism_address,
             };

--- a/cairo/crates/contracts/src/isms/trusted_relayer_ism.cairo
+++ b/cairo/crates/contracts/src/isms/trusted_relayer_ism.cairo
@@ -5,6 +5,7 @@ pub mod trusted_relayer_ism {
         IInterchainSecurityModule, IMailboxDispatcher, IMailboxDispatcherTrait, ModuleType,
     };
     use contracts::libs::message::{Message, MessageTrait};
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
     use starknet::ContractAddress;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     #[storage]
@@ -38,9 +39,9 @@ pub mod trusted_relayer_ism {
         /// # Returns
         ///
         /// boolean - wheter the verification succeed or not.
-        fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
+        fn verify(self: @ContractState, _metadata: @Bytes, _message: @Message) -> bool {
             let mailbox = IMailboxDispatcher { contract_address: self.mailbox.read() };
-            let (id, _) = MessageTrait::format_message(_message);
+            let (id, _) = MessageTrait::format_message(_message.clone());
             mailbox.processor(id) == self.trusted_relayer.read()
         }
     }

--- a/cairo/crates/contracts/src/libs/aggregation_ism_metadata.cairo
+++ b/cairo/crates/contracts/src/libs/aggregation_ism_metadata.cairo
@@ -3,8 +3,8 @@ pub mod aggregation_ism_metadata {
     use core::result::Result;
 
     pub trait AggregationIsmMetadata {
-        fn metadata_at(_metadata: Bytes, _index: u8) -> Bytes;
-        fn has_metadata(_metadata: Bytes, _index: u8) -> bool;
+        fn metadata_at(_metadata: @Bytes, _index: u8) -> Bytes;
+        fn has_metadata(_metadata: @Bytes, _index: u8) -> bool;
     }
     /// * Format of metadata:
     /// *
@@ -27,8 +27,8 @@ pub mod aggregation_ism_metadata {
         /// # Returns
         ///
         /// Bytes -  The metadata provided for the ISM at `_index`
-        fn metadata_at(_metadata: Bytes, _index: u8) -> Bytes {
-            let (mut start, end) = match metadata_range(_metadata.clone(), _index) {
+        fn metadata_at(_metadata: @Bytes, _index: u8) -> Bytes {
+            let (mut start, end) = match metadata_range(_metadata, _index) {
                 Result::Ok((start, end)) => (start, end),
                 Result::Err(_) => (0, 0),
             };
@@ -46,7 +46,7 @@ pub mod aggregation_ism_metadata {
         /// # Returns
         ///
         /// boolean -  Whether or not metadata was provided for the ISM at `_index`
-        fn has_metadata(_metadata: Bytes, _index: u8) -> bool {
+        fn has_metadata(_metadata: @Bytes, _index: u8) -> bool {
             match metadata_range(_metadata, _index) {
                 Result::Ok((start, _)) => start > 0,
                 Result::Err(_) => false,
@@ -66,7 +66,7 @@ pub mod aggregation_ism_metadata {
     ///
     /// Result<u32, u32), u8> -  Result on whether or not metadata was provided for the ISM at
     /// `_index`
-    fn metadata_range(_metadata: Bytes, _index: u8) -> Result<(u32, u32), u8> {
+    fn metadata_range(_metadata: @Bytes, _index: u8) -> Result<(u32, u32), u8> {
         let start = _index.into() * RANGE_SIZE * 2;
         let mid = start + RANGE_SIZE;
         let (_, mid_metadata) = _metadata.read_u32(mid.into());
@@ -95,7 +95,7 @@ mod test {
         let mut expected_result = array![0xAAAAAAAAAAAAAAAABBBBCCCC00000000_u256];
         let mut cur_idx = 0;
         while (cur_idx != 1) {
-            let result = AggregationIsmMetadata::metadata_at(encoded_metadata.clone(), 0);
+            let result = AggregationIsmMetadata::metadata_at(@encoded_metadata, 0);
             assert(
                 *BytesTrait::data(result.clone())[0] == *expected_result.at(cur_idx).low,
                 'Agg metadata extract failed',
@@ -131,7 +131,7 @@ mod test {
             0x582DE78DEDA234970000007D806349EA_u256,
             0xC6653E91900000000000000000000000_u256,
         ];
-        let result = AggregationIsmMetadata::metadata_at(encoded_metadata.clone(), 0);
+        let result = AggregationIsmMetadata::metadata_at(@encoded_metadata, 0);
 
         let mut cur_idx = 0;
         while (cur_idx != 9) {
@@ -154,7 +154,7 @@ mod test {
                 0x00000000000000000000000000000000,
             ],
         );
-        assert_eq!(AggregationIsmMetadata::has_metadata(encoded_metadata.clone(), 0), true);
-        assert_eq!(AggregationIsmMetadata::has_metadata(encoded_metadata.clone(), 1), false);
+        assert_eq!(AggregationIsmMetadata::has_metadata(@encoded_metadata, 0), true);
+        assert_eq!(AggregationIsmMetadata::has_metadata(@encoded_metadata, 1), false);
     }
 }

--- a/cairo/crates/contracts/src/libs/multisig/merkleroot_ism_metadata.cairo
+++ b/cairo/crates/contracts/src/libs/multisig/merkleroot_ism_metadata.cairo
@@ -2,12 +2,12 @@ pub mod merkleroot_ism_metadata {
     use alexandria_bytes::{Bytes, BytesStore, BytesTrait};
 
     pub trait MerkleRootIsmMetadata {
-        fn origin_merkle_tree_hook(_metadata: Bytes) -> u256;
-        fn message_index(_metadata: Bytes) -> u32;
-        fn signed_index(_metadata: Bytes) -> u32;
-        fn signed_message_id(_metadata: Bytes) -> u256;
-        fn proof(_metadata: Bytes) -> Span<u256>;
-        fn signature_at(_metadata: Bytes, _index: u32) -> (u8, u256, u256);
+        fn origin_merkle_tree_hook(_metadata: @Bytes) -> u256;
+        fn message_index(_metadata: @Bytes) -> u32;
+        fn signed_index(_metadata: @Bytes) -> u32;
+        fn signed_message_id(_metadata: @Bytes) -> u256;
+        fn proof(_metadata: @Bytes) -> Span<u256>;
+        fn signature_at(_metadata: @Bytes, _index: u32) -> (u8, u256, u256);
     }
 
     ///
@@ -39,7 +39,7 @@ pub mod merkleroot_ism_metadata {
         /// # Returns
         ///
         /// u256 -   Origin merkle tree hook of the signed checkpoint
-        fn origin_merkle_tree_hook(_metadata: Bytes) -> u256 {
+        fn origin_merkle_tree_hook(_metadata: @Bytes) -> u256 {
             let (_, felt) = _metadata.read_u256(ORIGIN_MERKLE_TREE_OFFSET);
             felt
         }
@@ -53,7 +53,7 @@ pub mod merkleroot_ism_metadata {
         /// # Returns
         ///
         /// u32 -   Index of the target message in the merkle tree.
-        fn message_index(_metadata: Bytes) -> u32 {
+        fn message_index(_metadata: @Bytes) -> u32 {
             let (_, felt) = _metadata.read_u32(MESSAGE_INDEX_OFFSET);
             felt
         }
@@ -67,7 +67,7 @@ pub mod merkleroot_ism_metadata {
         /// # Returns
         ///
         /// u32 -   Index of the signed checkpoint
-        fn signed_index(_metadata: Bytes) -> u32 {
+        fn signed_index(_metadata: @Bytes) -> u32 {
             let (_, felt) = _metadata.read_u32(SIGNED_INDEX_OFFSET);
             felt
         }
@@ -80,7 +80,7 @@ pub mod merkleroot_ism_metadata {
         /// # Returns
         ///
         /// u256 -   Message ID of the signed checkpoint
-        fn signed_message_id(_metadata: Bytes) -> u256 {
+        fn signed_message_id(_metadata: @Bytes) -> u256 {
             let (_, felt) = _metadata.read_u256(MESSAGE_ID_OFFSET);
             felt
         }
@@ -93,7 +93,7 @@ pub mod merkleroot_ism_metadata {
         /// # Returns
         ///
         /// Span<u256> -  Merkle proof branch of the message.
-        fn proof(_metadata: Bytes) -> Span<u256> {
+        fn proof(_metadata: @Bytes) -> Span<u256> {
             let mut bytes_arr = array![];
             let mut cur_idx = 0;
             loop {
@@ -119,7 +119,7 @@ pub mod merkleroot_ism_metadata {
         /// # Returns
         ///
         /// (u8, u256, u256) -  The validator ECDSA signature at `_index`.
-        fn signature_at(_metadata: Bytes, _index: u32) -> (u8, u256, u256) {
+        fn signature_at(_metadata: @Bytes, _index: u32) -> (u8, u256, u256) {
             // the first signer index is 0
             let (index_r, r) = _metadata.read_u256(SIGNATURES_OFFSET + SIGNATURE_LENGTH * _index);
             let (index_s, s) = _metadata.read_u256(index_r);

--- a/cairo/crates/contracts/src/libs/multisig/message_id_ism_metadata.cairo
+++ b/cairo/crates/contracts/src/libs/multisig/message_id_ism_metadata.cairo
@@ -3,10 +3,10 @@ pub mod message_id_ism_metadata {
 
 
     pub trait MessageIdIsmMetadata {
-        fn origin_merkle_tree_hook(_metadata: Bytes) -> u256;
-        fn root(_metadata: Bytes) -> u256;
-        fn index(_metadata: Bytes) -> u32;
-        fn signature_at(_metadata: Bytes, _index: u32) -> (u8, u256, u256);
+        fn origin_merkle_tree_hook(_metadata: @Bytes) -> u256;
+        fn root(_metadata: @Bytes) -> u256;
+        fn index(_metadata: @Bytes) -> u32;
+        fn signature_at(_metadata: @Bytes, _index: u32) -> (u8, u256, u256);
     }
 
 
@@ -31,7 +31,7 @@ pub mod message_id_ism_metadata {
         /// # Returns
         ///
         /// u256 -   Origin merkle tree hook of the signed checkpoint
-        fn origin_merkle_tree_hook(_metadata: Bytes) -> u256 {
+        fn origin_merkle_tree_hook(_metadata: @Bytes) -> u256 {
             let (_, felt) = _metadata.read_u256(ORIGIN_MERKLE_TREE_HOOK_OFFSET);
             felt
         }
@@ -45,7 +45,7 @@ pub mod message_id_ism_metadata {
         /// # Returns
         ///
         /// u256 -    Merkle root of the signed checkpoint
-        fn root(_metadata: Bytes) -> u256 {
+        fn root(_metadata: @Bytes) -> u256 {
             let (_, felt) = _metadata.read_u256(ROOT_OFFSET);
             felt
         }
@@ -58,7 +58,7 @@ pub mod message_id_ism_metadata {
         /// # Returns
         ///
         /// u32 -   Merkle index of the signed checkpoint
-        fn index(_metadata: Bytes) -> u32 {
+        fn index(_metadata: @Bytes) -> u32 {
             let (_, felt) = _metadata.read_u32(INDEX_OFFSET);
             felt
         }
@@ -76,7 +76,7 @@ pub mod message_id_ism_metadata {
         /// # Returns
         ///
         /// (u8, u256, u256) -  The validator ECDSA signature at `_index`.
-        fn signature_at(_metadata: Bytes, _index: u32) -> (u8, u256, u256) {
+        fn signature_at(_metadata: @Bytes, _index: u32) -> (u8, u256, u256) {
             // signature length set to 80 because u128 padding from the v param
             let (index_r, r) = _metadata.read_u256(SIGNATURE_OFFSET + SIGNATURE_LENGTH * _index);
             let (index_s, s) = _metadata.read_u256(index_r);

--- a/cairo/crates/contracts/src/mailbox.cairo
+++ b/cairo/crates/contracts/src/mailbox.cairo
@@ -7,7 +7,9 @@ pub mod mailbox {
         IPostDispatchHookDispatcher, IPostDispatchHookDispatcherTrait,
     };
     use contracts::libs::message::{HYPERLANE_VERSION, Message, MessageTrait};
-    use contracts::utils::utils::{U256TryIntoContractAddress, SerdeSnapshotBytes, SerdeSnapshotMessage};
+    use contracts::utils::utils::{
+        SerdeSnapshotBytes, SerdeSnapshotMessage, U256TryIntoContractAddress,
+    };
     use core::starknet::event::EventEmitter;
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
@@ -304,14 +306,12 @@ pub mod mailbox {
             let required_hook = IPostDispatchHookDispatcher {
                 contract_address: required_hook_address,
             };
-            let mut required_fee = required_hook
-                .quote_dispatch(@hook_metadata, @message);
+            let mut required_fee = required_hook.quote_dispatch(@hook_metadata, @message);
 
             let hook_dispatcher = IPostDispatchHookDispatcher { contract_address: hook };
-            let default_fee = hook_dispatcher
-                .quote_dispatch(@hook_metadata, @message);
+            let default_fee = hook_dispatcher.quote_dispatch(@hook_metadata, @message);
 
-        assert(_fee_amount >= required_fee + default_fee, Errors::NOT_ENOUGH_FEE_PROVIDED);
+            assert(_fee_amount >= required_fee + default_fee, Errors::NOT_ENOUGH_FEE_PROVIDED);
 
             let caller_address = get_caller_address();
             let contract_address = get_contract_address();

--- a/cairo/crates/contracts/src/serde_bytes.cairo
+++ b/cairo/crates/contracts/src/serde_bytes.cairo
@@ -6,7 +6,7 @@ impl SerdeBytes of Serde<Bytes> {
     fn serialize(self: @Bytes, ref output: Array<felt252>) {
         // Serialize length first
         Serde::<usize>::serialize(@self.len(), ref output);
-        
+
         // Serialize data
         let mut i: usize = 0;
         while i < self.len() {
@@ -18,7 +18,7 @@ impl SerdeBytes of Serde<Bytes> {
     fn deserialize(ref serialized: Span<felt252>) -> Option<Bytes> {
         // Deserialize length
         let len = Serde::<usize>::deserialize(ref serialized)?;
-        
+
         // Create bytes and append each byte
         let mut bytes = BytesTrait::new_empty();
         let mut i: usize = 0;
@@ -27,7 +27,7 @@ impl SerdeBytes of Serde<Bytes> {
             bytes.append_byte(byte);
             i += 1;
         }
-        
+
         Option::Some(bytes)
     }
 }
@@ -41,4 +41,4 @@ impl SerdeSnapshotBytes of Serde<@Bytes> {
     fn deserialize(ref serialized: Span<felt252>) -> Option<@Bytes> {
         Option::Some(@Serde::<Bytes>::deserialize(ref serialized)?)
     }
-} 
+}

--- a/cairo/crates/contracts/src/serde_bytes.cairo
+++ b/cairo/crates/contracts/src/serde_bytes.cairo
@@ -1,0 +1,44 @@
+use alexandria_bytes::bytes::{Bytes, BytesTrait};
+use core::array::ArrayTrait;
+use core::serde::{Serde, SerdeTrait};
+
+impl SerdeBytes of Serde<Bytes> {
+    fn serialize(self: @Bytes, ref output: Array<felt252>) {
+        // Serialize length first
+        Serde::<usize>::serialize(@self.len(), ref output);
+        
+        // Serialize data
+        let mut i: usize = 0;
+        while i < self.len() {
+            Serde::<u8>::serialize(@self.at(i), ref output);
+            i += 1;
+        }
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<Bytes> {
+        // Deserialize length
+        let len = Serde::<usize>::deserialize(ref serialized)?;
+        
+        // Create bytes and append each byte
+        let mut bytes = BytesTrait::new_empty();
+        let mut i: usize = 0;
+        while i < len {
+            let byte = Serde::<u8>::deserialize(ref serialized)?;
+            bytes.append_byte(byte);
+            i += 1;
+        }
+        
+        Option::Some(bytes)
+    }
+}
+
+// Also implement for snapshots which are used in interfaces
+impl SerdeSnapshotBytes of Serde<@Bytes> {
+    fn serialize(self: @@Bytes, ref output: Array<felt252>) {
+        Serde::<Bytes>::serialize(@self, ref output)
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<@Bytes> {
+        Option::Some(@Serde::<Bytes>::deserialize(ref serialized)?)
+    }
+} 

--- a/cairo/crates/contracts/src/utils/utils.cairo
+++ b/cairo/crates/contracts/src/utils/utils.cairo
@@ -1,7 +1,7 @@
-use crate::libs::message::Message;
-use starknet::ContractAddress;
 use alexandria_bytes::Bytes;
 use core::serde::Serde;
+use crate::libs::message::Message;
+use starknet::ContractAddress;
 
 pub impl U256TryIntoContractAddress of TryInto<u256, ContractAddress> {
     fn try_into(self: u256) -> Option<ContractAddress> {
@@ -12,7 +12,6 @@ pub impl U256TryIntoContractAddress of TryInto<u256, ContractAddress> {
         }
     }
 }
-
 
 
 pub impl SerdeSnapshotBytes of Serde<@Bytes> {

--- a/cairo/crates/contracts/src/utils/utils.cairo
+++ b/cairo/crates/contracts/src/utils/utils.cairo
@@ -1,4 +1,7 @@
+use crate::libs::message::Message;
 use starknet::ContractAddress;
+use alexandria_bytes::Bytes;
+use core::serde::Serde;
 
 pub impl U256TryIntoContractAddress of TryInto<u256, ContractAddress> {
     fn try_into(self: u256) -> Option<ContractAddress> {
@@ -9,3 +12,26 @@ pub impl U256TryIntoContractAddress of TryInto<u256, ContractAddress> {
         }
     }
 }
+
+
+
+pub impl SerdeSnapshotBytes of Serde<@Bytes> {
+    fn serialize(self: @@Bytes, ref output: Array<felt252>) {
+        Serde::<Bytes>::serialize(*self, ref output)
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<@Bytes> {
+        Option::Some(@Serde::<Bytes>::deserialize(ref serialized)?)
+    }
+}
+
+pub impl SerdeSnapshotMessage of Serde<@Message> {
+    fn serialize(self: @@Message, ref output: Array<felt252>) {
+        Serde::<Message>::serialize(*self, ref output)
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<@Message> {
+        Option::Some(@Serde::<Message>::deserialize(ref serialized)?)
+    }
+}
+

--- a/cairo/crates/contracts/tests/hooks/test_domain_routing_hook.cairo
+++ b/cairo/crates/contracts/tests/hooks/test_domain_routing_hook.cairo
@@ -29,7 +29,7 @@ fn test_supports_metadata_for_domain_routing_hook() {
     let (routing_hook_addrs, _) = setup_domain_routing_hook();
 
     let metadata = BytesTrait::new_empty();
-    assert_eq!(routing_hook_addrs.supports_metadata(metadata), true);
+    assert_eq!(routing_hook_addrs.supports_metadata(@metadata), true);
 }
 
 #[test]
@@ -112,7 +112,7 @@ fn hook_not_set_for_destination_should_fail() {
     };
     let metadata = BytesTrait::new_empty();
     let protocol_fee = 12_u256;
-    routing_hook_addrs.post_dispatch(metadata, message, protocol_fee);
+    routing_hook_addrs.post_dispatch(@metadata, @message, protocol_fee);
 }
 
 #[test]
@@ -193,10 +193,10 @@ fn hook_set_for_destination_post_dispatch() {
     cheat_caller_address(
         ownable.contract_address, NEW_OWNER().try_into().unwrap(), CheatSpan::TargetCalls(2),
     );
-    routing_hook_addrs.post_dispatch(metadata.clone(), message_1, PROTOCOL_FEE);
+    routing_hook_addrs.post_dispatch(@metadata, @message_1, PROTOCOL_FEE);
     assert_eq!(fee_token_instance.balance_of(NEW_OWNER().try_into().unwrap()), new_protocol_fee);
 
-    routing_hook_addrs.post_dispatch(metadata, message_2, new_protocol_fee);
+    routing_hook_addrs.post_dispatch(@metadata, @message_2, new_protocol_fee);
     assert_eq!(fee_token_instance.balance_of(NEW_OWNER().try_into().unwrap()), 0);
 }
 
@@ -228,7 +228,7 @@ fn test_post_dispatch_insufficient_fee() {
 
     // This should panic with 'Amount does not cover quote fee'
     // Assuming PROTOCOL_FEE is smaller than the required quote
-    routing_hook_addrs.post_dispatch(metadata, message, PROTOCOL_FEE / 2);
+    routing_hook_addrs.post_dispatch(@metadata, @message, PROTOCOL_FEE / 2);
 }
 
 #[test]
@@ -280,7 +280,7 @@ fn test_transfer_routing_fee_insufficient_balance() {
     cheat_caller_address(
         ownable.contract_address, NEW_OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
-    routing_hook_addrs.post_dispatch(metadata.clone(), message_1, PROTOCOL_FEE);
+    routing_hook_addrs.post_dispatch(@metadata, @message_1, PROTOCOL_FEE);
 }
 
 #[test]
@@ -335,7 +335,7 @@ fn test_transfer_routing_fee_insufficient_allowance() {
     cheat_caller_address(
         ownable.contract_address, NEW_OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
-    routing_hook_addrs.post_dispatch(metadata.clone(), message_1, PROTOCOL_FEE);
+    routing_hook_addrs.post_dispatch(@metadata, @message_1, PROTOCOL_FEE);
 }
 
 #[test]
@@ -385,6 +385,6 @@ fn hook_set_for_destination_quote_dispatch() {
         body: BytesTrait::new_empty(),
     };
     let metadata = BytesTrait::new_empty();
-    assert_eq!(routing_hook_addrs.quote_dispatch(metadata.clone(), message_1), PROTOCOL_FEE);
-    assert_eq!(routing_hook_addrs.quote_dispatch(metadata, message_2), new_protocol_fee);
+    assert_eq!(routing_hook_addrs.quote_dispatch(@metadata, @message_1), PROTOCOL_FEE);
+    assert_eq!(routing_hook_addrs.quote_dispatch(@metadata, @message_2), new_protocol_fee);
 }

--- a/cairo/crates/contracts/tests/hooks/test_merkle_tree_hook.cairo
+++ b/cairo/crates/contracts/tests/hooks/test_merkle_tree_hook.cairo
@@ -25,13 +25,13 @@ fn test_merkle_tree_hook_type() {
 fn test_supports_metadata() {
     let mut metadata = BytesTrait::new_empty();
     let (_, merkle_tree_hook, _) = setup_merkle_tree_hook();
-    assert_eq!(merkle_tree_hook.supports_metadata(metadata.clone()), true);
+    assert_eq!(merkle_tree_hook.supports_metadata(@metadata), true);
     let variant = 1;
     metadata.append_u16(variant);
-    assert_eq!(merkle_tree_hook.supports_metadata(metadata), true);
+    assert_eq!(merkle_tree_hook.supports_metadata(@metadata), true);
     metadata = BytesTrait::new_empty();
     metadata.append_u16(variant + 1);
-    assert_eq!(merkle_tree_hook.supports_metadata(metadata), false);
+    assert_eq!(merkle_tree_hook.supports_metadata(@metadata), false);
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn test_post_dispatch() {
         .dispatch(
             DESTINATION_DOMAIN,
             VALID_RECIPIENT(),
-            BytesTrait::new_empty(),
+            @BytesTrait::new_empty(),
             0,
             Option::None,
             Option::None,
@@ -67,7 +67,7 @@ fn test_post_dispatch() {
         recipient: VALID_RECIPIENT(),
         body: BytesTrait::new_empty(),
     };
-    post_dispatch_hook.post_dispatch(metadata, message, 0);
+    post_dispatch_hook.post_dispatch(@metadata, @message, 0);
     let expected_event = merkle_tree_hook::Event::InsertedIntoTree(
         merkle_tree_hook::InsertedIntoTree { id: id, index: count.try_into().unwrap() },
     );
@@ -91,7 +91,7 @@ fn test_post_dispatch_fails_if_message_not_dispatching() {
         recipient: VALID_RECIPIENT(),
         body: BytesTrait::new_empty(),
     };
-    post_dispatch_hook.post_dispatch(metadata, message, 0);
+    post_dispatch_hook.post_dispatch(@metadata, @message, 0);
 }
 #[test]
 #[should_panic(expected: ('Invalid metadata variant',))]
@@ -101,7 +101,7 @@ fn test_post_dispatch_fails_if_invalid_variant() {
     let variant = 2;
     metadata.append_u16(variant);
     let message = MessageTrait::default();
-    post_dispatch_hook.post_dispatch(metadata, message, 0);
+    post_dispatch_hook.post_dispatch(@metadata, @message, 0);
 }
 
 #[test]
@@ -111,7 +111,7 @@ fn test_quote_dispatch() {
     let variant = 1;
     metadata.append_u16(variant);
     let message = MessageTrait::default();
-    assert_eq!(post_dispatch_hook.quote_dispatch(metadata, message), 0);
+    assert_eq!(post_dispatch_hook.quote_dispatch(@metadata, @message), 0);
 }
 
 #[test]
@@ -122,7 +122,7 @@ fn test_quote_dispatch_fails_if_invalid_variant() {
     let variant = 2;
     metadata.append_u16(variant);
     let message = MessageTrait::default();
-    post_dispatch_hook.quote_dispatch(metadata, message);
+    post_dispatch_hook.quote_dispatch(@metadata, @message);
 }
 
 #[test]

--- a/cairo/crates/contracts/tests/hooks/test_protocol_fee.cairo
+++ b/cairo/crates/contracts/tests/hooks/test_protocol_fee.cairo
@@ -106,13 +106,13 @@ fn test_collect_protocol_fee_fails_if_insufficient_balance() {
 fn test_supports_metadata() {
     let mut metadata = BytesTrait::new_empty();
     let (_, post_dispatch_hook) = setup_protocol_fee(Option::None);
-    assert_eq!(post_dispatch_hook.supports_metadata(metadata.clone()), true);
+    assert_eq!(post_dispatch_hook.supports_metadata(@metadata), true);
     let variant = 1;
     metadata.append_u16(variant);
-    assert_eq!(post_dispatch_hook.supports_metadata(metadata), true);
+    assert_eq!(post_dispatch_hook.supports_metadata(@metadata), true);
     metadata = BytesTrait::new_empty();
     metadata.append_u16(variant + 1);
-    assert_eq!(post_dispatch_hook.supports_metadata(metadata), false);
+    assert_eq!(post_dispatch_hook.supports_metadata(@metadata), false);
 }
 
 
@@ -133,7 +133,7 @@ fn test_post_dispatch_fails_if_invalid_variant() {
     cheat_caller_address(
         ownable.contract_address, OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
-    post_dispatch_hook.post_dispatch(metadata, message, PROTOCOL_FEE);
+    post_dispatch_hook.post_dispatch(@metadata, @message, PROTOCOL_FEE);
 }
 
 
@@ -144,7 +144,7 @@ fn test_quote_dispatch() {
     let variant = 1;
     let message = MessageTrait::default();
     metadata.append_u16(variant);
-    assert_eq!(post_dispatch_hook.quote_dispatch(metadata, message), PROTOCOL_FEE);
+    assert_eq!(post_dispatch_hook.quote_dispatch(@metadata, @message), PROTOCOL_FEE);
 }
 
 
@@ -156,5 +156,5 @@ fn test_quote_dispatch_fails_if_invalid_variant() {
     let variant = 2;
     metadata.append_u16(variant);
     let message = MessageTrait::default();
-    post_dispatch_hook.quote_dispatch(metadata, message);
+    post_dispatch_hook.quote_dispatch(@metadata, @message);
 }

--- a/cairo/crates/contracts/tests/isms/test_aggregation.cairo
+++ b/cairo/crates/contracts/tests/isms/test_aggregation.cairo
@@ -111,7 +111,7 @@ fn test_aggregation_verify() {
     concat_metadata.concat(@message_id_metadata);
     // dummy metadata for noop ism
     concat_metadata.concat(@message_id_metadata);
-    assert(aggregation.verify(concat_metadata, message), 'Aggregation: verify failed');
+    assert(aggregation.verify(@concat_metadata, @message), 'Aggregation: verify failed');
 }
 
 
@@ -174,6 +174,6 @@ fn test_aggregation_verify_e2e() {
         aggregation_threshold.try_into().unwrap(),
     );
 
-    assert(aggregation.verify(metadata, message), 'Aggregation: verify failed');
+    assert(aggregation.verify(@metadata, @message), 'Aggregation: verify failed');
 }
 

--- a/cairo/crates/contracts/tests/isms/test_default_ism.cairo
+++ b/cairo/crates/contracts/tests/isms/test_default_ism.cairo
@@ -19,7 +19,7 @@ fn test_verify_noop_ism() {
     let noop_ism = setup_noop_ism();
     let message = MessageTrait::default();
     let metadata = BytesTrait::new_empty();
-    assert_eq!(noop_ism.verify(metadata, message), true);
+    assert_eq!(noop_ism.verify(@metadata, @message), true);
     assert_eq!(noop_ism.module_type(), ModuleType::NULL(()));
 }
 
@@ -52,8 +52,8 @@ fn test_verify_trusted_relayer_ism() {
         body: message_body.clone(),
     };
     let metadata = message_body;
-    mailbox.process(metadata.clone(), message.clone());
-    assert_eq!(trusted_ism.verify(metadata, message), true);
+    mailbox.process(@metadata, message.clone());
+    assert_eq!(trusted_ism.verify(@metadata, @message), true);
     assert_eq!(trusted_ism.module_type(), ModuleType::NULL(()));
 }
 
@@ -88,7 +88,7 @@ fn test_verify_pausable_ism() {
     let (pausable_ism, _) = setup_pausable_ism();
     let message = MessageTrait::default();
     let metadata = BytesTrait::new_empty();
-    assert_eq!(pausable_ism.verify(metadata, message), true);
+    assert_eq!(pausable_ism.verify(@metadata, @message), true);
     assert_eq!(pausable_ism.module_type(), ModuleType::NULL(()));
 }
 
@@ -103,5 +103,5 @@ fn test_veriy_pausable_ism_fails_if_paused() {
         ownable.contract_address, OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
     pausable.pause();
-    ism.verify(metadata, message);
+    ism.verify(@metadata, @message);
 }

--- a/cairo/crates/contracts/tests/isms/test_merkleroot_multisig.cairo
+++ b/cairo/crates/contracts/tests/isms/test_merkleroot_multisig.cairo
@@ -70,13 +70,8 @@ fn test_merkleroot_ism_metadata() {
         MerkleRootIsmMetadata::origin_merkle_tree_hook(@metadata) == origin_merkle_tree_hook,
         'wrong merkle tree hook',
     );
-    assert(
-        MerkleRootIsmMetadata::message_index(@metadata) == message_index,
-        'wrong message_index',
-    );
-    assert(
-        MerkleRootIsmMetadata::signed_index(@metadata) == signed_index, 'wrong signed index',
-    );
+    assert(MerkleRootIsmMetadata::message_index(@metadata) == message_index, 'wrong message_index');
+    assert(MerkleRootIsmMetadata::signed_index(@metadata) == signed_index, 'wrong signed index');
     assert(
         MerkleRootIsmMetadata::signed_message_id(@metadata) == signed_message_id,
         'wrong signed_message_id',

--- a/cairo/crates/contracts/tests/isms/test_merkleroot_multisig.cairo
+++ b/cairo/crates/contracts/tests/isms/test_merkleroot_multisig.cairo
@@ -67,21 +67,21 @@ fn test_merkleroot_ism_metadata() {
     let proof = TEST_PROOF();
     let (_, _, signatures) = get_merkle_message_and_signature();
     assert(
-        MerkleRootIsmMetadata::origin_merkle_tree_hook(metadata.clone()) == origin_merkle_tree_hook,
+        MerkleRootIsmMetadata::origin_merkle_tree_hook(@metadata) == origin_merkle_tree_hook,
         'wrong merkle tree hook',
     );
     assert(
-        MerkleRootIsmMetadata::message_index(metadata.clone()) == message_index,
+        MerkleRootIsmMetadata::message_index(@metadata) == message_index,
         'wrong message_index',
     );
     assert(
-        MerkleRootIsmMetadata::signed_index(metadata.clone()) == signed_index, 'wrong signed index',
+        MerkleRootIsmMetadata::signed_index(@metadata) == signed_index, 'wrong signed index',
     );
     assert(
-        MerkleRootIsmMetadata::signed_message_id(metadata.clone()) == signed_message_id,
+        MerkleRootIsmMetadata::signed_message_id(@metadata) == signed_message_id,
         'wrong signed_message_id',
     );
-    assert(MerkleRootIsmMetadata::proof(metadata.clone()) == proof, 'wrong proof');
+    assert(MerkleRootIsmMetadata::proof(@metadata) == proof, 'wrong proof');
     let y_parity = 0x01;
     let mut cur_idx = 0;
     loop {
@@ -90,7 +90,7 @@ fn test_merkleroot_ism_metadata() {
         }
         assert(
             MerkleRootIsmMetadata::signature_at(
-                metadata.clone(), cur_idx,
+                @metadata, cur_idx,
             ) == (y_parity, *signatures.at(cur_idx).r, *signatures.at(cur_idx).s),
             'wrong signature ',
         );
@@ -140,7 +140,7 @@ fn test_merkle_root_multisig_verify_with_4_valid_signatures() {
     let metadata = build_merkle_metadata(
         origin_merkle_tree_hook, message_index, signed_index, signed_message_id,
     );
-    assert(merkleroot_ism.verify(metadata, message) == true, 'verification failed');
+    assert(merkleroot_ism.verify(@metadata, @message), 'verification failed');
 }
 
 
@@ -173,7 +173,7 @@ fn test_merkle_root_multisig_verify_with_insufficient_valid_signatures() {
         origin_merkle_tree_hook, message_index, signed_index, signed_message_id,
     );
     metadata.update_at(1100, 0);
-    assert(merkleroot_ism.verify(metadata, message) == true, 'verification failed');
+    assert(merkleroot_ism.verify(@metadata, @message), 'verification failed');
 }
 
 
@@ -199,7 +199,7 @@ fn test_merkle_root_multisig_verify_with_empty_metadata() {
     let (_, validators_address, _) = get_merkle_message_and_signature();
     let (merkle_root_ism, _) = setup_merkleroot_multisig_ism(validators_address.span(), threshold);
     let bytes_metadata = BytesTrait::new_empty();
-    assert(merkle_root_ism.verify(bytes_metadata, message) == true, 'verification failed');
+    assert(merkle_root_ism.verify(@bytes_metadata, @message), 'verification failed');
 }
 
 
@@ -232,5 +232,5 @@ fn test_merkle_root_multisig_verify_with_4_valid_signatures_fails_if_duplicate_s
     let metadata = build_fake_merkle_metadata(
         origin_merkle_tree_hook, message_index, signed_index, signed_message_id,
     );
-    assert(merkleroot_ism.verify(metadata, message) == true, 'verification failed');
+    assert(merkleroot_ism.verify(@metadata, @message), 'verification failed');
 }

--- a/cairo/crates/contracts/tests/isms/test_messageid_multisig.cairo
+++ b/cairo/crates/contracts/tests/isms/test_messageid_multisig.cairo
@@ -15,9 +15,9 @@ use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::{CheatSpan, cheat_caller_address};
 use super::super::setup::{
-    DESTINATION_DOMAIN, LOCAL_DOMAIN, OWNER, VALIDATOR_ADDRESS_1,
-    VALIDATOR_ADDRESS_2, VALID_OWNER, VALID_RECIPIENT, build_fake_messageid_metadata,
-    build_messageid_metadata, get_message_and_signature, setup_messageid_multisig_ism,
+    DESTINATION_DOMAIN, LOCAL_DOMAIN, OWNER, VALIDATOR_ADDRESS_1, VALIDATOR_ADDRESS_2, VALID_OWNER,
+    VALID_RECIPIENT, build_fake_messageid_metadata, build_messageid_metadata,
+    get_message_and_signature, setup_messageid_multisig_ism,
 };
 
 

--- a/cairo/crates/contracts/tests/isms/test_messageid_multisig.cairo
+++ b/cairo/crates/contracts/tests/isms/test_messageid_multisig.cairo
@@ -15,7 +15,7 @@ use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use snforge_std::{CheatSpan, cheat_caller_address};
 use super::super::setup::{
-    DESTINATION_DOMAIN, LOCAL_DOMAIN, NEW_OWNER, OWNER, RECIPIENT_ADDRESS, VALIDATOR_ADDRESS_1,
+    DESTINATION_DOMAIN, LOCAL_DOMAIN, OWNER, VALIDATOR_ADDRESS_1,
     VALIDATOR_ADDRESS_2, VALID_OWNER, VALID_RECIPIENT, build_fake_messageid_metadata,
     build_messageid_metadata, get_message_and_signature, setup_messageid_multisig_ism,
 };
@@ -63,11 +63,11 @@ fn test_message_id_ism_metadata() {
     let (_, _, signatures) = get_message_and_signature();
     let metadata = build_messageid_metadata(origin_merkle_tree, root, index);
     assert(
-        MessageIdIsmMetadata::origin_merkle_tree_hook(metadata.clone()) == origin_merkle_tree,
+        MessageIdIsmMetadata::origin_merkle_tree_hook(@metadata) == origin_merkle_tree,
         'wrong merkle tree hook',
     );
-    assert(MessageIdIsmMetadata::root(metadata.clone()) == root, 'wrong root');
-    assert(MessageIdIsmMetadata::index(metadata.clone()) == index, 'wrong index');
+    assert(MessageIdIsmMetadata::root(@metadata) == root, 'wrong root');
+    assert(MessageIdIsmMetadata::index(@metadata) == index, 'wrong index');
     let mut cur_idx = 0;
     loop {
         if (cur_idx == signatures.len()) {
@@ -75,7 +75,7 @@ fn test_message_id_ism_metadata() {
         }
         assert(
             MessageIdIsmMetadata::signature_at(
-                metadata.clone(), cur_idx,
+                @metadata, cur_idx,
             ) == (y_parity, *signatures.at(cur_idx).r, *signatures.at(cur_idx).s),
             'wrong signature ',
         );
@@ -119,7 +119,7 @@ fn test_message_id_multisig_verify_with_4_valid_signatures() {
     let root: u256 = 'root'.try_into().unwrap();
     let index = 1;
     let metadata = build_messageid_metadata(origin_merkle_tree, root, index);
-    assert(messageid.verify(metadata, message) == true, 'verification failed');
+    assert(messageid.verify(@metadata, @message), 'verification failed');
 }
 
 
@@ -150,7 +150,7 @@ fn test_message_id_multisig_verify_with_insufficient_valid_signatures() {
     let mut metadata = build_messageid_metadata(origin_merkle_tree, root, index);
     // introduce an error for the signature
     metadata.update_at(80, 0);
-    assert(messageid.verify(metadata, message) == true, 'verification failed');
+    assert(messageid.verify(@metadata, @message), 'verification failed');
 }
 
 
@@ -176,7 +176,7 @@ fn test_message_id_multisig_verify_with_empty_metadata() {
     let (_, validators_address, _) = get_message_and_signature();
     let (messageid, _) = setup_messageid_multisig_ism(validators_address.span(), threshold);
     let bytes_metadata = BytesTrait::new_empty();
-    assert(messageid.verify(bytes_metadata, message) == true, 'verification failed');
+    assert(messageid.verify(@bytes_metadata, @message), 'verification failed');
 }
 
 
@@ -205,5 +205,5 @@ fn test_message_id_multisig_verify_with_4_valid_signatures_fails_if_duplicate_si
     let root: u256 = 'root'.try_into().unwrap();
     let index = 1;
     let metadata = build_fake_messageid_metadata(origin_merkle_tree, root, index);
-    assert(messageid.verify(metadata, message) == true, 'verification failed');
+    assert(messageid.verify(@metadata, @message), 'verification failed');
 }

--- a/cairo/crates/contracts/tests/routing/test_default_fallback_routing_ism.cairo
+++ b/cairo/crates/contracts/tests/routing/test_default_fallback_routing_ism.cairo
@@ -256,7 +256,7 @@ fn test_route_ism() {
         ownable.contract_address, OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
     fallback_routing_ism.initialize(_domains.span(), _modules.span());
-    assert_eq!(ism.route(message), *_modules.at(0));
+    assert_eq!(ism.route(@message), *_modules.at(0));
     message =
         Message {
             version: 3_u8,
@@ -267,7 +267,7 @@ fn test_route_ism() {
             recipient: 'RECIPIENT'.try_into().unwrap(),
             body: BytesTrait::new_empty(),
         };
-    assert_eq!(ism.route(message), *_modules.at(1));
+    assert_eq!(ism.route(@message), *_modules.at(1));
     message =
         Message {
             version: 3_u8,
@@ -278,7 +278,7 @@ fn test_route_ism() {
             recipient: 'RECIPIENT'.try_into().unwrap(),
             body: BytesTrait::new_empty(),
         };
-    assert_eq!(ism.route(message), *_modules.at(2));
+    assert_eq!(ism.route(@message), *_modules.at(2));
     message =
         Message {
             version: 3_u8,
@@ -290,7 +290,7 @@ fn test_route_ism() {
             body: BytesTrait::new_empty(),
         };
     let mailbox_dispatcher = IMailboxDispatcher { contract_address: MAILBOX() };
-    assert_eq!(ism.route(message), mailbox_dispatcher.get_default_ism());
+    assert_eq!(ism.route(@message), mailbox_dispatcher.get_default_ism());
 }
 
 
@@ -310,7 +310,6 @@ fn test_verify() {
         0x01020304050607080910111213141516,
         0x01020304050607080910000000000000,
     ];
-    let message_body = BytesTrait::new(42, array);
     let message = Message {
         version: HYPERLANE_VERSION,
         nonce: 0,
@@ -318,7 +317,7 @@ fn test_verify() {
         sender: VALID_OWNER(),
         destination: DESTINATION_DOMAIN,
         recipient: VALID_RECIPIENT(),
-        body: message_body.clone(),
+        body: BytesTrait::new(42, array),
     };
     let (_, validators_address, _) = get_message_and_signature();
     let (messageid, _) = setup_messageid_multisig_ism(validators_address.span(), threshold);
@@ -340,5 +339,5 @@ fn test_verify() {
         ownable.contract_address, OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
     fallback_routing_ism.initialize(_domains.span(), _modules.span());
-    assert_eq!(ism.verify(metadata, message), true);
+    assert_eq!(ism.verify(@metadata, @message), true);
 }

--- a/cairo/crates/contracts/tests/routing/test_domain_routing_ism.cairo
+++ b/cairo/crates/contracts/tests/routing/test_domain_routing_ism.cairo
@@ -238,7 +238,7 @@ fn test_route_ism() {
         ownable.contract_address, OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
     domain_routing_ism.initialize(_domains.span(), _modules.span());
-    assert_eq!(ism.route(message), *_modules.at(0));
+    assert_eq!(ism.route(@message), *_modules.at(0));
     message =
         Message {
             version: 3_u8,
@@ -249,7 +249,7 @@ fn test_route_ism() {
             recipient: 'RECIPIENT'.try_into().unwrap(),
             body: BytesTrait::new_empty(),
         };
-    assert_eq!(ism.route(message), *_modules.at(1));
+    assert_eq!(ism.route(@message), *_modules.at(1));
     message =
         Message {
             version: 3_u8,
@@ -260,7 +260,7 @@ fn test_route_ism() {
             recipient: 'RECIPIENT'.try_into().unwrap(),
             body: BytesTrait::new_empty(),
         };
-    assert_eq!(ism.route(message), *_modules.at(2));
+    assert_eq!(ism.route(@message), *_modules.at(2));
 }
 
 #[test]
@@ -287,7 +287,7 @@ fn test_route_ism_fails_if_origin_not_found() {
         ownable.contract_address, OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
     domain_routing_ism.initialize(_domains.span(), _modules.span());
-    ism.route(message);
+    ism.route(@message);
 }
 
 
@@ -307,7 +307,6 @@ fn test_verify() {
         0x01020304050607080910111213141516,
         0x01020304050607080910000000000000,
     ];
-    let message_body = BytesTrait::new(42, array);
     let message = Message {
         version: HYPERLANE_VERSION,
         nonce: 0,
@@ -315,7 +314,7 @@ fn test_verify() {
         sender: VALID_OWNER(),
         destination: DESTINATION_DOMAIN,
         recipient: VALID_RECIPIENT(),
-        body: message_body.clone(),
+        body: BytesTrait::new(42, array),
     };
     let (_, validators_address, _) = get_message_and_signature();
     let (messageid, _) = setup_messageid_multisig_ism(validators_address.span(), threshold);
@@ -337,5 +336,5 @@ fn test_verify() {
         ownable.contract_address, OWNER().try_into().unwrap(), CheatSpan::TargetCalls(1),
     );
     domain_routing_ism.initialize(_domains.span(), _modules.span());
-    assert_eq!(ism.verify(metadata, message), true);
+    assert_eq!(ism.verify(@metadata, @message), true);
 }

--- a/cairo/crates/contracts/tests/test_mailbox.cairo
+++ b/cairo/crates/contracts/tests/test_mailbox.cairo
@@ -158,14 +158,14 @@ fn test_dispatch() {
     let (message_id, _) = MessageTrait::format_message(message.clone());
     mailbox
         .dispatch(
-            DESTINATION_DOMAIN, RECIPIENT_ADDRESS(), message_body, 0, Option::None, Option::None,
+            DESTINATION_DOMAIN, RECIPIENT_ADDRESS(), @message_body, 0, Option::None, Option::None,
         );
     let expected_event = mailbox::Event::Dispatch(
         mailbox::Dispatch {
             sender: OWNER(),
             destination_domain: DESTINATION_DOMAIN,
             recipient_address: RECIPIENT_ADDRESS(),
-            message: message,
+            message: @message,
         },
     );
     let expected_event_id = mailbox::Event::DispatchId(mailbox::DispatchId { id: message_id });
@@ -223,7 +223,7 @@ fn test_dispatch_with_protocol_fee_hook() {
         .dispatch(
             DESTINATION_DOMAIN,
             RECIPIENT_ADDRESS(),
-            message_body,
+            @message_body,
             PROTOCOL_FEE,
             Option::None,
             Option::None,
@@ -233,7 +233,7 @@ fn test_dispatch_with_protocol_fee_hook() {
             sender: OWNER(),
             destination_domain: DESTINATION_DOMAIN,
             recipient_address: RECIPIENT_ADDRESS(),
-            message: message,
+            message: @message,
         },
     );
     let expected_event_id = mailbox::Event::DispatchId(mailbox::DispatchId { id: message_id });
@@ -295,7 +295,7 @@ fn test_dispatch_with_two_fee_hook() {
         .dispatch(
             DESTINATION_DOMAIN,
             RECIPIENT_ADDRESS(),
-            message_body,
+            @message_body,
             5 * PROTOCOL_FEE,
             Option::None,
             Option::None,
@@ -305,7 +305,7 @@ fn test_dispatch_with_two_fee_hook() {
             sender: OWNER(),
             destination_domain: DESTINATION_DOMAIN,
             recipient_address: RECIPIENT_ADDRESS(),
-            message: message,
+            message: @message,
         },
     );
     let expected_event_id = mailbox::Event::DispatchId(mailbox::DispatchId { id: message_id });
@@ -368,7 +368,7 @@ fn test_dispatch_with_two_fee_hook_fails_if_greater_than_required_and_lower_than
         .dispatch(
             DESTINATION_DOMAIN,
             RECIPIENT_ADDRESS(),
-            message_body,
+            @message_body,
             3 * PROTOCOL_FEE,
             Option::None,
             Option::None,
@@ -378,7 +378,7 @@ fn test_dispatch_with_two_fee_hook_fails_if_greater_than_required_and_lower_than
             sender: OWNER(),
             destination_domain: DESTINATION_DOMAIN,
             recipient_address: RECIPIENT_ADDRESS(),
-            message: message,
+            message: @message,
         },
     );
     let expected_event_id = mailbox::Event::DispatchId(mailbox::DispatchId { id: message_id });
@@ -428,12 +428,11 @@ fn test_dispatch_with_protocol_fee_hook_fails_if_provided_fee_lower_than_require
         0x01020304050607080910000000000000,
     ];
 
-    let message_body = BytesTrait::new(42, array);
     mailbox
         .dispatch(
             DESTINATION_DOMAIN,
             RECIPIENT_ADDRESS(),
-            message_body,
+            @BytesTrait::new(42, array),
             PROTOCOL_FEE - 10,
             Option::None,
             Option::None,
@@ -481,7 +480,7 @@ fn test_dispatch_with_protocol_fee_hook_fails_if_user_balance_lower_than_fee_amo
         .dispatch(
             DESTINATION_DOMAIN,
             RECIPIENT_ADDRESS(),
-            message_body,
+            @message_body,
             PROTOCOL_FEE,
             Option::None,
             Option::None,
@@ -530,7 +529,7 @@ fn test_dispatch_with_protocol_fee_hook_fails_if_insufficient_allowance() {
         .dispatch(
             DESTINATION_DOMAIN,
             RECIPIENT_ADDRESS(),
-            message_body,
+            @message_body,
             PROTOCOL_FEE,
             Option::None,
             Option::None,
@@ -566,7 +565,7 @@ fn test_process() {
     };
     let (message_id, _) = MessageTrait::format_message(message.clone());
     let metadata = message_body;
-    mailbox.process(metadata.clone(), message);
+    mailbox.process(@metadata, message);
     let expected_event = mailbox::Event::Process(
         mailbox::Process { origin: LOCAL_DOMAIN, sender: OWNER(), recipient: recipient.into() },
     );
@@ -616,7 +615,7 @@ fn test_process_fails_if_version_mismatch() {
         body: message_body.clone(),
     };
     let metadata = message_body;
-    mailbox.process(metadata.clone(), message);
+    mailbox.process(@metadata, message);
 }
 
 #[test]
@@ -647,7 +646,7 @@ fn test_process_fails_if_destination_domain_does_not_match_local_domain() {
         body: message_body.clone(),
     };
     let metadata = message_body;
-    mailbox.process(metadata.clone(), message);
+    mailbox.process(@metadata, message);
 }
 
 #[test]
@@ -679,9 +678,9 @@ fn test_process_fails_if_already_delivered() {
         body: message_body.clone(),
     };
     let metadata = message_body;
-    mailbox.process(metadata.clone(), message.clone());
+    mailbox.process(@metadata, message.clone());
     let (message_id, _) = MessageTrait::format_message(message.clone());
     assert(mailbox.delivered(message_id), 'Delivered status did not change');
-    mailbox.process(metadata.clone(), message);
+    mailbox.process(@metadata, message);
 }
 

--- a/cairo/crates/mocks/src/fee_hook.cairo
+++ b/cairo/crates/mocks/src/fee_hook.cairo
@@ -5,6 +5,7 @@ pub mod fee_hook {
         IPostDispatchHook, IPostDispatchHookDispatcher, IPostDispatchHookDispatcherTrait, Types,
     };
     use contracts::libs::message::Message;
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
     use starknet::ContractAddress;
 
     #[storage]
@@ -16,15 +17,15 @@ pub mod fee_hook {
             Types::UNUSED(())
         }
 
-        fn supports_metadata(self: @ContractState, _metadata: Bytes) -> bool {
+        fn supports_metadata(self: @ContractState, _metadata: @Bytes) -> bool {
             true
         }
 
         fn post_dispatch(
-            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256,
+            ref self: ContractState, _metadata: @Bytes, _message: @Message, _fee_amount: u256,
         ) {}
 
-        fn quote_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) -> u256 {
+        fn quote_dispatch(ref self: ContractState, _metadata: @Bytes, _message: @Message) -> u256 {
             3000000
         }
     }

--- a/cairo/crates/mocks/src/hook.cairo
+++ b/cairo/crates/mocks/src/hook.cairo
@@ -1,9 +1,7 @@
 #[starknet::contract]
 pub mod hook {
     use alexandria_bytes::{Bytes, BytesStore};
-    use contracts::interfaces::{
-        IPostDispatchHook, Types,
-    };
+    use contracts::interfaces::{IPostDispatchHook, Types};
     use contracts::libs::message::Message;
     use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
 

--- a/cairo/crates/mocks/src/hook.cairo
+++ b/cairo/crates/mocks/src/hook.cairo
@@ -1,10 +1,11 @@
 #[starknet::contract]
 pub mod hook {
-    use alexandria_bytes::{Bytes, BytesStore, BytesTrait};
+    use alexandria_bytes::{Bytes, BytesStore};
     use contracts::interfaces::{
-        IPostDispatchHook, IPostDispatchHookDispatcher, IPostDispatchHookDispatcherTrait, Types,
+        IPostDispatchHook, Types,
     };
     use contracts::libs::message::Message;
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
 
     #[storage]
     struct Storage {}
@@ -15,15 +16,15 @@ pub mod hook {
             Types::UNUSED(())
         }
 
-        fn supports_metadata(self: @ContractState, _metadata: Bytes) -> bool {
+        fn supports_metadata(self: @ContractState, _metadata: @Bytes) -> bool {
             true
         }
 
         fn post_dispatch(
-            ref self: ContractState, _metadata: Bytes, _message: Message, _fee_amount: u256,
+            ref self: ContractState, _metadata: @Bytes, _message: @Message, _fee_amount: u256,
         ) {}
 
-        fn quote_dispatch(ref self: ContractState, _metadata: Bytes, _message: Message) -> u256 {
+        fn quote_dispatch(ref self: ContractState, _metadata: @Bytes, _message: @Message) -> u256 {
             0_u256
         }
     }

--- a/cairo/crates/mocks/src/ism.cairo
+++ b/cairo/crates/mocks/src/ism.cairo
@@ -5,8 +5,8 @@ pub mod ism {
         IInterchainSecurityModule, IInterchainSecurityModuleDispatcher,
         IInterchainSecurityModuleDispatcherTrait, ModuleType,
     };
-    use contracts::libs::message::{Message, MessageTrait};
-    use starknet::ContractAddress;
+    use contracts::libs::message::Message;
+    use contracts::utils::utils::{SerdeSnapshotBytes, SerdeSnapshotMessage};
 
     #[storage]
     struct Storage {}
@@ -16,7 +16,7 @@ pub mod ism {
             ModuleType::MESSAGE_ID_MULTISIG(starknet::get_contract_address())
         }
 
-        fn verify(self: @ContractState, _metadata: Bytes, _message: Message) -> bool {
+        fn verify(self: @ContractState, _metadata: @Bytes, _message: @Message) -> bool {
             true
         }
     }

--- a/cairo/crates/mocks/src/mock_mailbox.cairo
+++ b/cairo/crates/mocks/src/mock_mailbox.cairo
@@ -325,7 +325,7 @@ pub mod MockMailbox {
         fn process_next_inbound_message(ref self: ContractState) {
             let message = self.inbound_messages.read(self.inbound_processed_nonce.read());
             IMailboxDispatcher { contract_address: starknet::get_contract_address() }
-                .process(BytesTrait::new_empty(), message);
+                .process(@BytesTrait::new_empty(), message);
             self.inbound_processed_nonce.write(self.inbound_processed_nonce.read() + 1);
         }
         fn get_local_domain(self: @ContractState) -> u32 {
@@ -444,7 +444,7 @@ pub mod MockMailbox {
                 );
             self.emit(ProcessId { id: id });
 
-            assert(ism.verify(_metadata, _message.clone()), Errors::ISM_VERIFICATION_FAILED);
+            assert(ism.verify(@_metadata, @_message), Errors::ISM_VERIFICATION_FAILED);
 
             let message_recipient = IMessageRecipientDispatcher {
                 contract_address: _message.recipient.try_into().unwrap(),

--- a/cairo/crates/mocks/src/test_post_dispatch_hook.cairo
+++ b/cairo/crates/mocks/src/test_post_dispatch_hook.cairo
@@ -15,7 +15,6 @@ pub trait ITestPostDispatchHook<TContractState> {
 
 #[starknet::contract]
 pub mod TestPostDispatchHook {
-    use super::*;
     use alexandria_bytes::BytesTrait;
     use contracts::hooks::libs::standard_hook_metadata::standard_hook_metadata::{
         StandardHookMetadata, VARIANT,
@@ -25,6 +24,7 @@ pub mod TestPostDispatchHook {
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
+    use super::*;
     #[storage]
     struct Storage {
         fee: u256,

--- a/cairo/crates/token/src/components/fast_token_router.cairo
+++ b/cairo/crates/token/src/components/fast_token_router.cairo
@@ -184,7 +184,7 @@ pub mod FastTokenRouterComponent {
             let message_body = TokenMessageTrait::format(recipient, amount_or_id, metadata);
             let hook = mailbox_comp.get_hook();
             let message_id = gas_router_comp
-                ._Gas_router_dispatch(destination, value, message_body, hook);
+                ._Gas_router_dispatch(destination, value, @message_body, hook);
 
             token_router_comp
                 .emit(

--- a/cairo/crates/token/src/components/token_router.cairo
+++ b/cairo/crates/token/src/components/token_router.cairo
@@ -267,14 +267,14 @@ pub impl TokenRouterTransferRemoteHookDefaultImpl<
 
                 message_id = router_comp
                     ._Router_dispatch(
-                        destination, value, token_message, hook_metadata, hook.unwrap(),
+                        destination, value, @token_message, hook_metadata, hook.unwrap(),
                     );
             },
             Option::None => {
                 let hook_metadata = gas_router_comp._Gas_router_hook_metadata(destination);
                 let hook = mailbox_comp.get_hook();
                 message_id = router_comp
-                    ._Router_dispatch(destination, value, token_message, hook_metadata, hook);
+                    ._Router_dispatch(destination, value, @token_message, hook_metadata, hook);
             },
         }
 

--- a/cairo/crates/token/src/extensions/hyp_erc20_vault.cairo
+++ b/cairo/crates/token/src/extensions/hyp_erc20_vault.cairo
@@ -194,7 +194,7 @@ mod HypErc20Vault {
                     message_id = contract_state
                         .router
                         ._Router_dispatch(
-                            destination, value, token_message, hook_metadata, hook.unwrap(),
+                            destination, value, @token_message, hook_metadata, hook.unwrap(),
                         );
                 },
                 Option::None => {
@@ -204,7 +204,7 @@ mod HypErc20Vault {
                     let hook = contract_state.mailbox.get_hook();
                     message_id = contract_state
                         .router
-                        ._Router_dispatch(destination, value, token_message, hook_metadata, hook);
+                        ._Router_dispatch(destination, value, @token_message, hook_metadata, hook);
                 },
             }
 

--- a/cairo/crates/token/src/extensions/hyp_erc20_vault_collateral.cairo
+++ b/cairo/crates/token/src/extensions/hyp_erc20_vault_collateral.cairo
@@ -182,7 +182,7 @@ mod HypErc20VaultCollateral {
                     message_id = contract_state
                         .router
                         ._Router_dispatch(
-                            destination, value, token_message, hook_metadata, hook.unwrap(),
+                            destination, value, @token_message, hook_metadata, hook.unwrap(),
                         );
                 },
                 Option::None => {
@@ -192,7 +192,7 @@ mod HypErc20VaultCollateral {
                     let hook = contract_state.mailbox.get_hook();
                     message_id = contract_state
                         .router
-                        ._Router_dispatch(destination, value, token_message, hook_metadata, hook);
+                        ._Router_dispatch(destination, value, @token_message, hook_metadata, hook);
                 },
             }
 


### PR DESCRIPTION
- Snapshot uses a pointer instead of copying the data type every time. 
- This needed serde trait implementation for @Bytes (SerdeSnapshotBytes) and @Message (SerdeSnapshotMessage), which reside in the util.cairo file.

Related issue

fixes https://linear.app/hyperlane-xyz/issue/ENG-1212/fix-clone-issue-for-bytes-in-cairo