### PR TITLE
chore: add max_protocol_fee getter

### DIFF
--- a/cairo/crates/contracts/src/hooks/protocol_fee.cairo
+++ b/cairo/crates/contracts/src/hooks/protocol_fee.cairo
@@ -132,6 +132,10 @@ pub mod protocol_fee {
             self._set_protocol_fee(_protocol_fee);
         }
 
+        fn get_max_protocol_fee(self: @ContractState) -> u256 {
+            self.max_protocol_fee.read()
+        }
+
         fn get_beneficiary(self: @ContractState) -> ContractAddress {
             self.beneficiary.read()
         }

--- a/cairo/crates/contracts/src/interfaces.cairo
+++ b/cairo/crates/contracts/src/interfaces.cairo
@@ -281,6 +281,8 @@ pub trait IProtocolFee<TContractState> {
 
     fn set_protocol_fee(ref self: TContractState, _protocol_fee: u256);
 
+    fn get_max_protocol_fee(self: @TContractState) -> u256;
+
     fn get_beneficiary(self: @TContractState) -> ContractAddress;
 
     fn set_beneficiary(ref self: TContractState, _beneficiary: ContractAddress);


### PR DESCRIPTION
from @troykessler: "This PR adds a getter for the `max_protocol_fee` property in the protocol fee contract, fulfilling the solity contract: https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/hooks/ProtocolFee.sol#L41"